### PR TITLE
feat: Superchain migration notice on welcome page

### DIFF
--- a/apps/web/src/components/welcome/NewSafe.tsx
+++ b/apps/web/src/components/welcome/NewSafe.tsx
@@ -1,24 +1,61 @@
 import React from 'react'
-import { Grid, SvgIcon, Typography } from '@mui/material'
+import { Box, Button, Grid, List, ListItem, Stack, Typography } from '@mui/material'
+import { WarningAmberOutlined, OpenInNewRounded } from '@mui/icons-material'
 import css from './styles.module.css'
-import CheckFilled from '@/public/images/common/check-filled.svg'
 
 import WelcomeLogin from './WelcomeLogin'
-import NetworkList from '../common/NetworkSelector/NetworkList'
+import ChainIndicator from '@/components/common/ChainIndicator'
+import useChains from '@/hooks/useChains'
+import { PROTOFIRE_SAFE_URL } from '@/config/constants'
 
-const BulletListItem = ({ text }: { text: string }) => (
-  <li>
-    <SvgIcon className={css.checkIcon} component={CheckFilled} inheritViewBox />
-    <Typography
-      sx={{
-        color: 'static.main',
-        fontWeight: 700,
-      }}
-    >
-      {text}
+// Networks whose Safe support is moving from Superchain Safe to Protofire Safe.
+const AFFECTED_NETWORK_NAMES = ['Cyber', 'Superseed', 'Soneium', 'Ink', 'Lisk', 'Metal L2']
+
+const NetworkChip = ({ chainId, chainName }: { chainId: string; chainName: string }) => (
+  <Stack
+    direction="row"
+    alignItems="center"
+    gap={1}
+    sx={{
+      px: 1.5,
+      py: 1,
+      borderRadius: 1.5,
+      border: '1px solid rgba(0, 0, 0, 0.12)',
+      backgroundColor: 'rgba(255, 255, 255, 0.6)',
+    }}
+  >
+    <ChainIndicator chainId={chainId} onlyLogo inline />
+    <Typography variant="body2" sx={{ fontWeight: 700, color: 'static.main' }}>
+      {chainName}
     </Typography>
-  </li>
+  </Stack>
 )
+
+const AffectedNetworks = () => {
+  const { configs } = useChains()
+  const affected = configs.filter((chain) => AFFECTED_NETWORK_NAMES.includes(chain.chainName))
+
+  if (!affected.length) return null
+
+  return (
+    <>
+      <Typography variant="h5" sx={{ mt: 1, fontWeight: 700, color: 'static.main' }}>
+        Affected networks
+      </Typography>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', sm: '1fr 1fr 1fr' },
+          gap: 1.5,
+        }}
+      >
+        {affected.map((chain) => (
+          <NetworkChip key={chain.chainId} chainId={chain.chainId} chainName={chain.chainName} />
+        ))}
+      </Box>
+    </>
+  )
+}
 
 const NewSafe = () => {
   return (
@@ -48,31 +85,70 @@ const NewSafe = () => {
             <Typography
               variant="h1"
               sx={{
-                fontSize: [44, null, 52],
-                lineHeight: 1,
-                letterSpacing: -1.5,
+                fontSize: [32, null, 40],
+                lineHeight: 1.1,
+                letterSpacing: -1,
                 color: 'static.main',
               }}
             >
-              Unlock a new way of ownership
+              These networks have moved to Protofire Safe
             </Typography>
 
-            <Typography
+            <Stack
+              direction="row"
+              gap={1.5}
+              alignItems="flex-start"
               sx={{
-                mb: 1,
-                color: 'static.main',
+                my: 1,
+                p: 2,
+                borderRadius: 1.5,
+                border: '1px solid #f5a623',
+                backgroundColor: 'rgba(245, 166, 35, 0.12)',
               }}
             >
-              The most trusted decentralized custody protocol and collective asset management platform.
+              <WarningAmberOutlined sx={{ color: '#e08600', mt: '2px' }} />
+              <Box>
+                <Typography sx={{ fontWeight: 700, color: 'static.main' }}>
+                  Superchain Safe support for these networks is ending
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'static.main' }}>
+                  Continue on Protofire Safe — your accounts and funds are unchanged.
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Typography variant="h5" sx={{ mt: 1, fontWeight: 700, color: 'static.main' }}>
+              Why the change
+            </Typography>
+            <List sx={{ listStyleType: 'disc', pl: 3, py: 0, m: 0, color: 'static.main' }}>
+              <ListItem sx={{ display: 'list-item', px: 0, py: 0.5 }}>
+                The Superchain Safe interface previously hosted for these networks by the Protofire team has been
+                discontinued.
+              </ListItem>
+              <ListItem sx={{ display: 'list-item', px: 0, py: 0.5 }}>
+                Protofire now provides one dedicated interface for them at app.safe.protofire.io.
+              </ListItem>
+            </List>
+
+            <Typography sx={{ color: 'static.main' }}>
+              Your Safe accounts, owners, and funds are unchanged — only the website URL is different. Your assets live
+              on-chain and remain fully under your control.
             </Typography>
 
-            <ul className={css.bulletList}>
-              <BulletListItem text="Stealth security with multiple signers" />
-              <BulletListItem text="Create safes seamlessly across Superchain" />
-              <BulletListItem text="Make it yours with modules, guards and ecosystem apps" />
-              <BulletListItem text="Available at these networks:" />
-              <NetworkList />
-            </ul>
+            <AffectedNetworks />
+
+            <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+              <Button
+                variant="contained"
+                size="large"
+                href={PROTOFIRE_SAFE_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                endIcon={<OpenInNewRounded />}
+              >
+                Open Protofire Safe
+              </Button>
+            </Box>
           </div>
         </Grid>
       </Grid>

--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -70,6 +70,9 @@ export enum SafeAppsTag {
 
 export const HELP_CENTER_URL = 'https://safe-support.protofire.io'
 
+// Protofire Safe (destination for the Superchain networks migration)
+export const PROTOFIRE_SAFE_URL = 'https://app.safe.protofire.io'
+
 // Safe Apps names
 export enum SafeAppsName {
   CSV = 'CSV Airdrop',


### PR DESCRIPTION
## What

Replaces the marketing content (\"Unlock a new way of ownership\") in the **welcome page left block** with a migration notice telling users that the affected Superchain networks have moved to Protofire Safe. Content is adapted from the \`superchain-migration\` page built on the shared UI.

## Changes

- **\`apps/web/src/components/welcome/NewSafe.tsx\`**
  - Title: \"These networks have moved to Protofire Safe\"
  - Amber/warning callout: \"Superchain Safe support for these networks is ending\"
  - \"Why the change\" bullet list + funds-unchanged reassurance
  - \"Affected networks\" chips (Cyber, Superseed, Soneium, Ink, Lisk, Metal L2) rendered via the existing \`ChainIndicator\`, filtered from \`useChains()\` (self-hides if none configured)
  - Centered, filled CTA button linking externally to Protofire Safe
  - Removed the old marketing block and its now-unused imports
- **\`apps/web/src/config/constants.ts\`** — added \`PROTOFIRE_SAFE_URL\`

The right-hand login panel and the light card container are unchanged.

## Notes

- Content kept on the existing light card; child components restyled with light-card-friendly colors instead of theme palette.
- Not visually verified in-browser (Chrome extension not connected during dev); lint + typecheck pass.